### PR TITLE
fix dbm

### DIFF
--- a/encode.py
+++ b/encode.py
@@ -55,10 +55,10 @@ def encode_word(callsign, locator, dbm):
     assert n_locator >= 179
     assert n_locator <= 32220
 
-    assert dbm > -64
-    assert dbm < 64
-    n_dbm = 64 + dbm
-
+    assert 0 <= dbm <= 60
+    corr = [0, -1, 1, 0, -1, 2, 1, 0, -1, 1]
+    n_dbm = dbm + corr[dbm % 10] + 64
+    
     n = (n_callsign << (15+7)) | (n_locator << 7) | n_dbm
 
     # MSB -> LSB order


### PR DESCRIPTION
input dbm from 0 -> 0.001 W to 60 -> 1000 W
also apply "correction" because some values, es 1,2,4, etc
are used by type 2 and type 3 messages.

This seems to work for me and messages are correctly decoded by wsjt-x 